### PR TITLE
Include full path in Putsinator output

### DIFF
--- a/lib/putsinator.rb
+++ b/lib/putsinator.rb
@@ -1,21 +1,12 @@
 module Kernel
-  def noisy_puts( *args )
-    file, line = caller[0].split(':')
-    file = File.basename file
-    
-    default_puts "[#{file}:#{line}]", *args
+  [:p, :puts].each do |meth|
+    default, noisy = "default_#{meth}", "noisy_#{meth}"
+
+    define_method noisy do |*args|
+      send(default, "# Putsinator detected #{meth} at #{caller[0]}", *args)
+    end
+
+    alias_method default, meth
+    alias_method meth, noisy
   end
-  
-  alias_method :default_puts, :puts
-  alias_method :puts, :noisy_puts
-  
-  def noisy_p( *args )
-    file, line = caller[0].split(':')
-    file = File.basename file
-    
-    default_p "[#{file}:#{line}]", *args
-  end
-  
-  alias_method :default_p, :p
-  alias_method :p, :noisy_p
 end

--- a/test/putsinator_test.rb
+++ b/test/putsinator_test.rb
@@ -7,25 +7,21 @@ class PutsinatorTest < Test::Unit::TestCase
   def setup
     @file = File.basename __FILE__
   end
-    
-  def test_that_puts_fingers_the_file_that_did_it
-    stringy = "I'm putsing from a test whoooo"
-    
-    line = 0
-    out = capture_stdout do
-      line = __LINE__; puts stringy
-    end
-    
-    assert_equal "[#{@file}:#{line}]\n#{stringy}\n", out.string
-  end
-  
-  def test_that_p_fingers_the_culprit
-    string = "Foo"
-    line = 0
-    out = capture_stdout do
-      line = __LINE__; p string
-    end
 
-    assert_equal "\"[#{@file}:#{line}]\"\n#{string.inspect}\n", out.string
+  [:p, :puts].each do |meth|
+    define_method "test_that_#{meth}_fingers_the_file_that_did_it" do
+      stringy = "I'm #{meth}ing from a test whoooo"
+
+      line = 0
+      out = capture_stdout do
+        line = __LINE__; send(meth, stringy)
+      end
+
+      assert_match @file, out.string
+      assert_match /#{line}/, out.string
+      assert_match stringy, out.string
+      assert_match 'Putsinator', out.string # make sure the developer can find _us_ if desired
+    end
   end
+
 end


### PR DESCRIPTION
Modified gem to output the full path of the offending file and dry'ed up the tests and implementation.
